### PR TITLE
Make background transparent in custom header

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This makes the original Home Assistant header "compact" and also matches it with
 Click on the three dots on the top right, then go to `Configure UI` then `Raw config editor` and add the following:
 
 ``` yaml
+# Example entry
 custom_header:
   # Makes header compact
   compact_mode: true

--- a/README.md
+++ b/README.md
@@ -138,12 +138,21 @@ This makes the original Home Assistant header "compact" and also matches it with
 Click on the three dots on the top right, then go to `Configure UI` then `Raw config editor` and add the following:
 
 ``` yaml
-# Example entry
 custom_header:
+  # Makes header compact
   compact_mode: true
+  # Makes background transparent
   background: transparent
-  tab_indicator_color: var(--primary-text-color)
+  # Hide help (Just another thing that I'd google, not look in my sidebar)
+  hide_help: true
+  # Makes tabs the same color as the text color
   elements_color: var(--primary-text-color)
+  # Makes line under selected tab color same as sidebar selected panel color
+  tab_indicator_color: var(--sidebar-selected-icon-color)
+  # Makes selected tab color same as sidebar selected panel color
+  active_tab_color: var(--sidebar-selected-icon-color)
+  # Make mobile view notification dot color same as selected panel color
+  notification_dot_color: var(--sidebar-selected-icon-color)
 ```
 
 ## Text Header Card

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Click on the three dots on the top right, then go to `Configure UI` then `Raw co
 # Example entry
 custom_header:
   compact_mode: true
-  background: var(--primary-background-color)
+  background: transparent
   tab_indicator_color: var(--primary-text-color)
   elements_color: var(--primary-text-color)
 ```


### PR DESCRIPTION
I found out that if you set the background to transparent, it still matches the theme, but it's see-through. This way, if you have a scrollable UI, you can see more at once.
Side note: I've been using this more advanced config, and it's been working pretty well.
```yaml
custom_header:
  # Makes selected tab color same as sidebar selected panel color
  active_tab_color: var(--sidebar-selected-icon-color)
  # Makes background transparent
  background: transparent
  # Makes header compact
  compact_mode: true
  # Makes tabs the same color as the text color
  elements_color: var(--primary-text-color)
  # Hides custom header settings (I find the UI unreliable)
  hide_ch_settings: true
  # Hide help (Just another thing that I'd google, not look in my sidebar)
  hide_help: true
  # Make mobile view notification dot color same as selected panel color
  notification_dot_color: var(--sidebar-selected-icon-color)
  # Makes line under selected tab color same as sidebar selected panel color
  tab_indicator_color: var(--sidebar-selected-icon-color)
```