### PR TITLE
Make automation even shorter (@Harry-1976)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,7 @@ You will need to set up an automation to automatically switch to a dark theme at
         data:
 # Change this to the name of your light theme
           name: Name of your light theme
-    - conditions:
-      - condition: state
-        entity_id: sun.sun
-        state: "below_horizon"
-      sequence:
+    default:
       - service: frontend.set_theme
         data:
 # Change this to the name of your light theme


### PR DESCRIPTION
As **Hary-1976** suggested, you can make the automation even shorter by using a default. The only thing is if `sun.sun` is something other than `above_horizon` or `below_horizon`, it'll use the dark theme.